### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import { readFile } from "fs/promises";
+import * as fs from "fs";
 import { join } from "path";
 
 const app = express();
@@ -7,7 +8,13 @@ const app = express();
 app.get("/unsafe/:path", async (req, res) => {
   try {
     const { path } = req.params;
-    const file = await readFile(path);
+    const SAFE_ROOT = "/safe/root/directory";
+    const resolvedPath = fs.realpathSync(join(SAFE_ROOT, path));
+    if (!resolvedPath.startsWith(SAFE_ROOT)) {
+      res.status(403).send("Forbidden: Invalid file path");
+      return;
+    }
+    const file = await readFile(resolvedPath);
     const contents = file.toString();
     res.send(contents);
   } catch (e) {


### PR DESCRIPTION
Potential fix for [https://github.com/dominictassio/expressway/security/code-scanning/1](https://github.com/dominictassio/expressway/security/code-scanning/1)

To fix the issue, we need to validate and sanitize the user-provided `path` before using it to access files. The best approach is to ensure that the file path is resolved within a safe root directory and does not allow access to files outside this directory. This can be achieved by:

1. Defining a safe root directory (e.g., `SAFE_ROOT`).
2. Using `path.resolve` to normalize the user-provided path relative to the safe root directory.
3. Using `fs.realpathSync` to resolve symbolic links in the path.
4. Verifying that the resolved path starts with the safe root directory.
5. Rejecting requests with invalid paths by returning an appropriate HTTP status code.

This fix ensures that the application only accesses files within the intended directory and prevents directory traversal attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
